### PR TITLE
Command impex:

### DIFF
--- a/sfcc-cli-tools/commands/Impex.cs
+++ b/sfcc-cli-tools/commands/Impex.cs
@@ -84,16 +84,31 @@ namespace sfcc_cli_tools.commands
         /// <returns>Returns a flag indicating the success./returns>
         public bool ProcessOption(string optionName, string[] args)
         {
+            bool success = false;
             switch(optionName)
             {
                 case "new":
-                    if (args.Length > 0 && args[0] != "-h")
-                    {
+                    if (args.Length > 0 && args[0] != "-h" && args[0] != "--help")
+                    {   
 
+                    }
+                    else
+                    {
+                        PrintHelp("new");
                     }
                     break;
                 case "run":
-                    /// TODO: Process run option of impex command.
+                    /// TODO: Process sftools impex run
+                    break;
+                case "set":
+                    if (args.Length > 0 && args[0] != "-h" && args[0] != "--help")
+                    {
+                        /// TODO: Process: sftools impex set
+                    }
+                    else
+                    {
+                        PrintHelp("set");
+                    }
                     break;
                 default:
                     break;


### PR DESCRIPTION
- Added additional logic to the impex command process option switch to check for the help flag on the new & set options and send to the PrintHelp(string: subCommand) method if no options were specified.